### PR TITLE
Rewrite installer tasks

### DIFF
--- a/src/main/groovy/net/minecraftforge/forgedev/ForgeDevExtension.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/ForgeDevExtension.java
@@ -4,10 +4,12 @@
  */
 package net.minecraftforge.forgedev;
 
+import net.minecraftforge.forgedev.legacy.values.CIRuntime;
 import net.minecraftforge.forgedev.tasks.compat.LegacyExtractZip;
 import net.minecraftforge.forgedev.tasks.compat.LegacyMergeFilesTask;
 import net.minecraftforge.forgedev.tasks.filtering.LegacyFilterNewJar;
 import net.minecraftforge.forgedev.tasks.generation.GeneratePatcherConfigV2;
+import net.minecraftforge.forgedev.tasks.installer.Installer;
 import net.minecraftforge.forgedev.tasks.installertools.DownloadMappings;
 import net.minecraftforge.forgedev.tasks.launcher.SlimeLauncherExec;
 import net.minecraftforge.forgedev.tasks.mappings.LegacyApplyMappings;
@@ -47,6 +49,7 @@ import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.tasks.bundling.Zip;
 import org.gradle.api.tasks.compile.JavaCompile;
+import org.gradle.internal.Actions;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.plugins.ide.eclipse.model.EclipseModel;
 import org.jetbrains.annotations.VisibleForTesting;
@@ -77,9 +80,14 @@ public abstract class ForgeDevExtension {
 
     protected abstract @Inject ProjectLayout getProjectLayout();
 
+    private final Project project;
+    private final Provider<Boolean> isCi;
+
     @Inject
     public ForgeDevExtension(ForgeDevPlugin plugin, Project project) {
         this.mavenizerRepo.set(plugin.globalCaches().dir("repo").map(this.problems.ensureFileLocation()));
+        this.project = project;
+        this.isCi = getProviders().of(CIRuntime.class, it -> {});
         this.setup(plugin, project);
     }
 
@@ -99,6 +107,22 @@ public abstract class ForgeDevExtension {
     private Configuration minecraftDepsConfiguration;
     public Configuration getMinecraftConfiguration() {
         return this.minecraftDepsConfiguration;
+    }
+
+    public Installer installer() {
+        return installer(Installer.DEFAULT_NAME);
+    }
+    public Installer installer(String name) {
+        return installer(name, i -> {});
+    }
+    public Installer installer(String name, Action<Installer> action) {
+        var ret = Installer.register(this.project, this, name);
+        action.execute(ret);
+        return ret;
+    }
+
+    public boolean isCi() {
+        return this.isCi.get();
     }
 
     private void setup(ForgeDevPlugin plugin, Project project) {

--- a/src/main/groovy/net/minecraftforge/forgedev/ForgeDevExtension.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/ForgeDevExtension.java
@@ -4,6 +4,7 @@
  */
 package net.minecraftforge.forgedev;
 
+import net.minecraftforge.forgedev.legacy.tasks.DownloadDependency;
 import net.minecraftforge.forgedev.legacy.values.CIRuntime;
 import net.minecraftforge.forgedev.tasks.compat.LegacyExtractZip;
 import net.minecraftforge.forgedev.tasks.compat.LegacyMergeFilesTask;
@@ -37,6 +38,7 @@ import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.DuplicatesStrategy;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.JavaPlugin;
@@ -111,6 +113,9 @@ public abstract class ForgeDevExtension {
 
     public Installer installer() {
         return installer(Installer.DEFAULT_NAME);
+    }
+    public Installer installer(Action<Installer> action) {
+        return installer(Installer.DEFAULT_NAME, action);
     }
     public Installer installer(String name) {
         return installer(name, i -> {});

--- a/src/main/groovy/net/minecraftforge/forgedev/Tools.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/Tools.java
@@ -14,6 +14,7 @@ public final class Tools {
     public static final Tool DIFFPATCH = Tool.of("diffpatch", "io.codechicken:DiffPatch:2.1.0.42:all", Constants.MAVEN_CENTRAL, 8);
     public static final Tool BINPATCH = Tool.ofForge("binpatcher", "net.minecraftforge:binarypatcher:1.2.2:fatjar", 8);
     public static final Tool INSTALLERTOOLS = Tool.ofForge("installertools", "net.minecraftforge:installertools:1.4.4:fatjar", 8);
+    public static final Tool INSTALLER = Tool.ofForge("installer", "net.minecraftforge:installer:2.2.9:fatjar", 8);
     public static final Tool JARCOMPATIBILITYCHECKER = Tool.ofForge("jarcompatibilitychecker", "net.minecraftforge:JarCompatibilityChecker:0.1.28:all", 8);
     public static final Tool RENAMER = Tool.ofForge("renamer", "net.minecraftforge:ForgeAutoRenamingTool:1.1.1:all", 8);
     public static final Tool SRG2SRC = Tool.ofForge("srg2source", "net.minecraftforge:Srg2Source:8.1.1:fatjar", 17);

--- a/src/main/groovy/net/minecraftforge/forgedev/Util.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/Util.java
@@ -5,26 +5,7 @@
 package net.minecraftforge.forgedev;
 
 import net.minecraftforge.gradleutils.shared.SharedUtil;
-import org.gradle.TaskExecutionRequest;
-import org.gradle.api.Action;
-import org.gradle.api.Project;
-import org.gradle.api.plugins.JavaPluginExtension;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.specs.Spec;
-import org.gradle.api.tasks.TaskProvider;
-import org.gradle.jvm.toolchain.JavaLanguageVersion;
-import org.gradle.jvm.toolchain.JavaLauncher;
-import org.gradle.jvm.toolchain.JavaToolchainService;
-import org.gradle.jvm.toolchain.JavaToolchainSpec;
-import org.jetbrains.annotations.Nullable;
-
-import java.io.File;
-import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.concurrent.Callable;
 
 public final class Util extends SharedUtil {
     private Util() { }

--- a/src/main/groovy/net/minecraftforge/forgedev/legacy/tasks/CheckForgeJarCompatibility.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/legacy/tasks/CheckForgeJarCompatibility.java
@@ -104,6 +104,17 @@ public class CheckForgeJarCompatibility {
             task.getInputJar().set(reobfJar.flatMap(LegacyReobfuscateJar::getOutput));
         });
         checkJarCompatibility.configure(action);
+
+        var providers = project.getProviders();
+        var hasMaven = providers.environmentVariable("MAVEN_USER").isPresent() && providers.environmentVariable("MAVEN_PASSWORD").isPresent();
+        var checkCompatibility = providers.gradleProperty("net.minecraftforge.forge.build.check.compatibility").map(Boolean::parseBoolean).getOrElse(false);
+
+        if (!hasMaven && checkCompatibility) {
+            project.getTasks().named("check", task -> {
+                task.dependsOn(checkJarCompatibility);
+            });
+        }
+
         return checkJarCompatibility;
     }
 

--- a/src/main/groovy/net/minecraftforge/forgedev/legacy/tasks/DownloadDependency.groovy
+++ b/src/main/groovy/net/minecraftforge/forgedev/legacy/tasks/DownloadDependency.groovy
@@ -23,6 +23,12 @@ import javax.inject.Inject
 @CompileStatic
 abstract class DownloadDependency extends DefaultTask {
     static TaskProvider<DownloadDependency> register(Project project, String name, Object dependency) {
+        return project.tasks.register(name, DownloadDependency) {
+            it.artifact = dependency;
+        }
+    }
+
+    public void setArtifact(Object dependency) {
         final def unpacked
         if (dependency instanceof ProviderConvertible<?>)
             unpacked = dependency.asProvider().get()
@@ -42,15 +48,13 @@ abstract class DownloadDependency extends DefaultTask {
             }
         )
 
-        project.tasks.register(name, DownloadDependency) {
-            it.output.fileProvider(it.providers.provider {
-                try {
-                    configuration.singleFile
-                } catch (IllegalStateException e) {
-                    throw new IllegalArgumentException('Downloaded dependency variant is not a single file', e)
-                }
-            })
-        }
+        output.fileProvider(providers.provider {
+            try {
+                configuration.singleFile
+            } catch (IllegalStateException e) {
+                throw new IllegalArgumentException('Downloaded dependency variant is not a single file', e)
+            }
+        })
     }
 
     abstract @OutputFile RegularFileProperty getOutput()

--- a/src/main/groovy/net/minecraftforge/forgedev/legacy/tasks/InstallerJar.groovy
+++ b/src/main/groovy/net/minecraftforge/forgedev/legacy/tasks/InstallerJar.groovy
@@ -22,7 +22,6 @@ abstract class InstallerJar extends Zip {
     @Input @Optional abstract Property<Boolean> getFat()
     @Input @Optional abstract Property<Boolean> getOffline()
 
-
     protected abstract @Inject ProjectLayout getLayout()
     protected abstract @Inject ProviderFactory getProviders()
 

--- a/src/main/groovy/net/minecraftforge/forgedev/legacy/tasks/InstallerJar.groovy
+++ b/src/main/groovy/net/minecraftforge/forgedev/legacy/tasks/InstallerJar.groovy
@@ -22,6 +22,7 @@ abstract class InstallerJar extends Zip {
     @Input @Optional abstract Property<Boolean> getFat()
     @Input @Optional abstract Property<Boolean> getOffline()
 
+
     protected abstract @Inject ProjectLayout getLayout()
     protected abstract @Inject ProviderFactory getProviders()
 

--- a/src/main/groovy/net/minecraftforge/forgedev/legacy/tasks/Util.groovy
+++ b/src/main/groovy/net/minecraftforge/forgedev/legacy/tasks/Util.groovy
@@ -12,10 +12,13 @@ import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
 import net.minecraftforge.forgedev.legacy.values.LibraryInfo
 import net.minecraftforge.forgedev.legacy.values.MinimalResolvedArtifact
+import net.minecraftforge.gradleutils.shared.SharedUtil
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ResolvedArtifact
+import org.gradle.api.provider.HasConfigurableValue
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.SetProperty
@@ -181,11 +184,11 @@ final class Util {
     }
 
     @CompileDynamic
-    private static Provider<Map<String, MinimalResolvedArtifact>> artifactTree(Project project, String artifact, boolean transitive = true) {
+    static Provider<Map<String, MinimalResolvedArtifact>> artifactTree(Project project, String artifact, boolean transitive = true) {
         return MinimalResolvedArtifact.from(project, project.configurations.detachedConfiguration(
             project.dependencies.create(artifact)
         ).tap { it.transitive = transitive }).map { list ->
-            var map = new HashMap<String, MinimalResolvedArtifact>(list.size())
+            var map = new LinkedHashMap<String, MinimalResolvedArtifact>(list.size())
             for (var minimal in list) {
                 map.put(minimal.info().key(), minimal)
             }
@@ -238,5 +241,33 @@ final class Util {
                 }
             }
         }
+    }
+
+    @CompileDynamic
+    static String asArtifactString(Object artifact) {
+        def value = SharedUtil.unpack(artifact)
+        if (!(value instanceof Dependency))
+            throw new IllegalArgumentException("Cannot get non-dependency as artifact string! Found: $value.class")
+
+        def classifier = value.hasProperty('classifier') ? ":$value.classifier" : ''
+        def extension = value.hasProperty('artifactType') ? "@$value.artifactType" : value.hasProperty('extension') ? "@$value.extension" : ''
+        classifier = classifier != ':null' ? classifier : ''
+        extension = extension != '@null' ? extension : ''
+
+        "$value.group:$value.name:$value.version$classifier$extension".toString()
+    }
+
+    static <R extends HasConfigurableValue> R finalize(Project project, R ret) {
+        ret.disallowChanges();
+        ret.finalizeValueOnRead();
+        return ret;
+    }
+
+    static String capitalize(String s) {
+        return s.capitalize();
+    }
+
+    static String kebab(String s) {
+        s.replaceAll('([A-Z])', '-$1').toLowerCase()
     }
 }

--- a/src/main/groovy/net/minecraftforge/forgedev/legacy/values/LibraryInfo.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/legacy/values/LibraryInfo.java
@@ -5,22 +5,39 @@
 package net.minecraftforge.forgedev.legacy.values;
 
 import net.minecraftforge.forgedev.legacy.tasks.Util;
+import org.gradle.api.Action;
 import org.gradle.api.Project;
+import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
+import org.gradle.plugins.ide.eclipse.model.Library;
 
 import java.io.File;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Semaphore;
 
 public record LibraryInfo(String name, Downloads downloads) implements Serializable {
     public record Downloads(ArtifactInfo artifact) implements Serializable {
-        public record ArtifactInfo(String path, String url, String sha1, long size) implements Serializable {
+        public static class ArtifactInfo  implements Serializable {
+            public String path;
+            public String url;
+            public String sha1;
+            public long size;
+
+            public ArtifactInfo(String path, String url, String sha1, long size) {
+                this.path = path;
+                this.url = url;
+                this.sha1 = sha1;
+                this.size = size;
+            }
+
             public ArtifactInfo validateUrl(boolean offline) {
                 if (offline || !url.startsWith("https://libraries.minecraft.net/"))
                     return this;
@@ -57,39 +74,46 @@ public record LibraryInfo(String name, Downloads downloads) implements Serializa
         return from(dependencies, Boolean.valueOf(validateUrl));
     }
 
+    public static LibraryInfo from(MinimalResolvedArtifact dependency) {
+        var info = dependency.info();
+        var url = "https://libraries.minecraft.net/" + info.path();
+        if (!Util.checkExists(url))
+            url = "https://maven.minecraftforge.net/" + info.path();
+
+        var file = dependency.file();
+        var sha1 = Util.sha1(dependency.file());
+
+        return new LibraryInfo(
+            info.name(),
+            info.path(),
+            url,
+            sha1,
+            file.length()
+        );
+    }
+
     private static Map<String, LibraryInfo> from(Collection<MinimalResolvedArtifact> dependencies, Boolean offline) {
-        var ret = new HashMap<String, LibraryInfo>(dependencies.size());
+        var ret = new LinkedHashMap<String, LibraryInfo>(dependencies.size());
         var semaphore = new Semaphore(1, true);
         dependencies.parallelStream().forEachOrdered(dependency -> {
-            var info = dependency.info();
-            var url = "https://libraries.minecraft.net/" + info.path();
-            if (!Util.checkExists(url))
-                url = "https://maven.minecraftforge.net/" + info.path();
-
-            var file = dependency.file();
-            var sha1 = Util.sha1(dependency.file());
+            var library = from(dependency);
+            if (offline != null)
+                library = library.validateUrl(offline);
 
             try {
                 semaphore.acquire();
+                ret.put(dependency.info().key(), library);
+                semaphore.release();
             } catch (InterruptedException e) {
                 throw new RuntimeException("Interrupted while trying to get library info for " + dependency.info(), e);
             }
-
-            var library = new LibraryInfo(
-                info.name(),
-                info.path(),
-                url,
-                sha1,
-                file.length()
-            );
-            if (offline != null)
-                library = library.validateUrl(offline);
-            ret.put(info.key(), library);
-
-            semaphore.release();
         });
 
         return ret;
+    }
+
+    public static Provider<LibraryInfo> from(Project project, TaskProvider<? extends AbstractArchiveTask> task) {
+        return MinimalResolvedArtifact.from(project, task).map(LibraryInfo::from);
     }
 
     @SafeVarargs
@@ -100,17 +124,21 @@ public record LibraryInfo(String name, Downloads downloads) implements Serializa
         }
 
         var ret = project.getObjects().mapProperty(String.class, LibraryInfo.class).value(dependencies.map(LibraryInfo::from));
-
-        ret.disallowChanges();
-        ret.finalizeValueOnRead();
-        if (project.getState().getExecuted()) {
-            ret.finalizeValue();
-        }
-
-        return ret;
+        return Util.finalize(project, ret);
     }
 
     public static Provider<Map<String, LibraryInfo>> from(Project project, Configuration configuration) {
         return MinimalResolvedArtifact.from(project, configuration).map(LibraryInfo::from);
+    }
+
+    public static List<LibraryInfo> toList(List<MinimalResolvedArtifact> list) {
+        return list.stream().map(LibraryInfo::from).toList();
+    }
+
+    public static Transformer<LibraryInfo, LibraryInfo> apply(Action<LibraryInfo> action) {
+        return info -> {
+            action.execute(info);
+            return info;
+        };
     }
 }

--- a/src/main/groovy/net/minecraftforge/forgedev/legacy/values/MavenInfo.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/legacy/values/MavenInfo.java
@@ -27,6 +27,32 @@ public record MavenInfo(String key, String name, String path, ArtifactInfo art) 
         return this.key.compareTo(that.key);
     }
 
+    public static MavenInfo from(String gav) {
+        var parts =  gav.split(":");
+        var group =  parts[0];
+        var name = parts[1];
+        var version = parts[2];
+
+        String classifier = null;
+        String extension = null;
+
+        if (parts.length > 3) {
+            classifier = parts[3];
+            var idx = classifier.indexOf('@');
+            if (idx != -1) {
+                classifier = classifier.substring(0, idx);
+                extension = classifier.substring(idx + 1);
+            }
+        } else {
+            var idx = version.indexOf('@');
+            if (idx != -1) {
+                version = version.substring(0, idx);
+                extension = version.substring(idx + 1);
+            }
+        }
+        return from(group, name, version, classifier, extension);
+    }
+
     public static MavenInfo from(String artGroup, String artName, String artVersion, @Nullable String artClassifier, @Nullable String artExtension) {
         if (artExtension == null)
             artExtension = "jar";

--- a/src/main/groovy/net/minecraftforge/forgedev/legacy/values/MinimalResolvedArtifact.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/legacy/values/MinimalResolvedArtifact.java
@@ -6,6 +6,7 @@ package net.minecraftforge.forgedev.legacy.values;
 
 import net.minecraftforge.forgedev.legacy.tasks.Util;
 import org.gradle.api.Project;
+import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
@@ -49,31 +50,18 @@ public record MinimalResolvedArtifact(MavenInfo info, File file) implements Seri
 
     public static Provider<List<MinimalResolvedArtifact>> from(Project project, Configuration configuration) {
         var ret = project.getObjects().listProperty(MinimalResolvedArtifact.class);
-
-        var configurations = project.getConfigurations();
-
-        // Find any artifacts from the 'installer' config
-        // This config specifies the runtime files we intend for the installer to have.
-        // And are typically what we would be developing and testing alongside Forge.
-        // So we may have local modified versions
-        for (var dependency : configuration.getDependencies()) {
-            if (dependency instanceof ProjectDependency projectDependency) {
-                from(project, projectDependency, ret);
-            } else {
-                var c = configurations.detachedConfiguration(dependency);
-                ret.addAll(c.getIncoming().getArtifacts().getResolvedArtifacts().map(MinimalResolvedArtifact::transform));
-            }
-        }
-
+        ret.addAll(configuration.getIncoming().getArtifacts().getResolvedArtifacts().map(transform(project)));
         return Util.finalize(project, ret);
     }
 
-    private static List<MinimalResolvedArtifact> transform(Set<ResolvedArtifactResult> results) {
-        var artifacts = new ArrayList<MinimalResolvedArtifact>(results.size());
-        for (var artifact : results) {
-            artifacts.add(MinimalResolvedArtifact.from(null, artifact));
-        }
-        return artifacts;
+    private static Transformer<List<MinimalResolvedArtifact>, Set<ResolvedArtifactResult>> transform(Project project) {
+        return results -> {
+            var artifacts = new ArrayList<MinimalResolvedArtifact>(results.size());
+            for (var artifact : results) {
+                artifacts.add(MinimalResolvedArtifact.from(project, artifact));
+            }
+            return artifacts;
+        };
     }
 
     public static Provider<MinimalResolvedArtifact> single(Project project, String artifact) {
@@ -92,7 +80,7 @@ public record MinimalResolvedArtifact(MavenInfo info, File file) implements Seri
             project.getDependencies().create(artifact)
         );
         c.setTransitive(transitive);
-        ret.set(c.getIncoming().getArtifacts().getResolvedArtifacts().map(MinimalResolvedArtifact::transform));
+        ret.set(c.getIncoming().getArtifacts().getResolvedArtifacts().map(transform(project)));
         return Util.finalize(project, ret);
     }
 

--- a/src/main/groovy/net/minecraftforge/forgedev/legacy/values/MinimalResolvedArtifact.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/legacy/values/MinimalResolvedArtifact.java
@@ -4,11 +4,13 @@
  */
 package net.minecraftforge.forgedev.legacy.values;
 
+import net.minecraftforge.forgedev.legacy.tasks.Util;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.RegularFile;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskProvider;
@@ -19,6 +21,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 public record MinimalResolvedArtifact(MavenInfo info, File file) implements Serializable {
     private static Provider<MinimalResolvedArtifact> from(Project project, ProjectDependency projectDependency, FileCollection files) {
@@ -26,28 +29,17 @@ public record MinimalResolvedArtifact(MavenInfo info, File file) implements Seri
         var ret = project.getObjects().property(MinimalResolvedArtifact.class).value(project.provider(files::getSingleFile).map(file ->
             new MinimalResolvedArtifact(info, file)
         ));
-
-        ret.disallowChanges();
-        ret.finalizeValueOnRead();
-        if (project.getState().getExecuted()) {
-            ret.finalizeValue();
-        }
-
-        return ret;
+        return Util.finalize(project, ret);
     }
 
     public static Provider<MinimalResolvedArtifact> from(Project project, TaskProvider<? extends AbstractArchiveTask> task) {
-        var ret = project.getObjects().property(MinimalResolvedArtifact.class).value(project.getProviders().zip(MavenInfo.from(project, task), task.flatMap(AbstractArchiveTask::getArchiveFile), (info, regularFile) ->
-            new MinimalResolvedArtifact(info, regularFile.getAsFile())
-        ));
-
-        ret.disallowChanges();
-        ret.finalizeValueOnRead();
-        if (project.getState().getExecuted()) {
-            ret.finalizeValue();
-        }
-
-        return ret;
+        var ret = project.getObjects().property(MinimalResolvedArtifact.class).value(
+            MavenInfo.from(project, task).zip(
+                task.flatMap(AbstractArchiveTask::getArchiveFile).map(RegularFile::getAsFile),
+                MinimalResolvedArtifact::new
+            )
+        );
+        return Util.finalize(project, ret);
     }
 
     public static MinimalResolvedArtifact from(Project project, ResolvedArtifactResult artifact) {
@@ -61,7 +53,7 @@ public record MinimalResolvedArtifact(MavenInfo info, File file) implements Seri
         var configurations = project.getConfigurations();
 
         // Find any artifacts from the 'installer' config
-        // This config specifies the runtime files we intend for the interaller to have.
+        // This config specifies the runtime files we intend for the installer to have.
         // And are typically what we would be developing and testing alongside Forge.
         // So we may have local modified versions
         for (var dependency : configuration.getDependencies()) {
@@ -69,23 +61,39 @@ public record MinimalResolvedArtifact(MavenInfo info, File file) implements Seri
                 from(project, projectDependency, ret);
             } else {
                 var c = configurations.detachedConfiguration(dependency);
-                ret.addAll(c.getIncoming().getArtifacts().getResolvedArtifacts().map(results -> {
-                    var artifacts = new ArrayList<MinimalResolvedArtifact>(results.size());
-                    for (var artifact : results) {
-                        artifacts.add(MinimalResolvedArtifact.from(null, artifact));
-                    }
-                    return artifacts;
-                }));
+                ret.addAll(c.getIncoming().getArtifacts().getResolvedArtifacts().map(MinimalResolvedArtifact::transform));
             }
         }
 
-        ret.disallowChanges();
-        ret.finalizeValueOnRead();
-        if (project.getState().getExecuted()) {
-            ret.finalizeValue();
-        }
+        return Util.finalize(project, ret);
+    }
 
-        return ret;
+    private static List<MinimalResolvedArtifact> transform(Set<ResolvedArtifactResult> results) {
+        var artifacts = new ArrayList<MinimalResolvedArtifact>(results.size());
+        for (var artifact : results) {
+            artifacts.add(MinimalResolvedArtifact.from(null, artifact));
+        }
+        return artifacts;
+    }
+
+    public static Provider<MinimalResolvedArtifact> single(Project project, String artifact) {
+        return from(project, artifact, false).map(l -> l.get(0));
+    }
+    public static Provider<MinimalResolvedArtifact> from(MavenInfo info, Provider<RegularFile> file) {
+        return file.map(f -> new MinimalResolvedArtifact(info, f.getAsFile()));
+    }
+    public static Provider<List<MinimalResolvedArtifact>> from(Project project, String artifact) {
+        return from(project, artifact, true);
+    }
+    public static Provider<List<MinimalResolvedArtifact>> from(Project project, String artifact, boolean transitive) {
+        var ret = project.getObjects().listProperty(MinimalResolvedArtifact.class);
+
+        var c = project.getConfigurations().detachedConfiguration(
+            project.getDependencies().create(artifact)
+        );
+        c.setTransitive(transitive);
+        ret.set(c.getIncoming().getArtifacts().getResolvedArtifacts().map(MinimalResolvedArtifact::transform));
+        return Util.finalize(project, ret);
     }
 
     private static void from(Project project, ProjectDependency projectDependency, ListProperty<MinimalResolvedArtifact> ret) {

--- a/src/main/groovy/net/minecraftforge/forgedev/tasks/SingleFileOutput.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/tasks/SingleFileOutput.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+package net.minecraftforge.forgedev.tasks;
+
+import org.gradle.api.file.RegularFileProperty;
+
+public interface SingleFileOutput {
+    RegularFileProperty getOutput();
+}

--- a/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/Installer.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/Installer.java
@@ -194,7 +194,7 @@ public abstract class Installer {
         var self = project.getProviders().provider(() -> holder.value);
 
         var base = DownloadDependency.register(project, name + "DownloadBase", Tools.INSTALLER.getModule().toString());
-        var jarConfig = tasks.register(name + "JarConfig", InstallerJarConfig.class, self);
+        var jarConfig = tasks.register(name + "JarConfig", InstallerJarConfig.class, self, base);
         var jar = tasks.register(name + "Jar", InstallerJar.class);
         var json = tasks.register(name + "Json", InstallerJson.class);
         var launcherJson = tasks.register(name + "LauncherJson", LauncherJson.class);
@@ -212,10 +212,6 @@ public abstract class Installer {
                 json,
                 launcherJson
             );
-
-            task.from(project.zipTree(base.map(DownloadDependency::getOutput)), cfg -> {
-               cfg.setDuplicatesStrategy(DuplicatesStrategy.EXCLUDE);
-            });
         });
 
         json.configure(task -> {

--- a/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/Installer.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/Installer.java
@@ -215,7 +215,7 @@ public abstract class Installer {
         });
 
         json.configure(task -> {
-            task.getOutput().set(baseDir.file("installer_profile.json"));
+            task.getOutput().set(baseDir.file("install_profile.json"));
         });
 
         launcherJson.configure(task -> {

--- a/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/Installer.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/Installer.java
@@ -43,6 +43,7 @@ public abstract class Installer {
     private final String name;
     // Public facing tasks
     private final TaskProvider<InstallerJar> jar;
+    private final TaskProvider<InstallerJarConfig> jarConfig;
     private final TaskProvider<InstallerJson> json;
     private final TaskProvider<LauncherJson> launcherJson;
 
@@ -50,19 +51,20 @@ public abstract class Installer {
     private final TaskProvider<DownloadDependency> base;
 
     @Input
-    public abstract Property<Boolean> getCi();
+    public abstract Property<Boolean> getDev();
     @Input
     public abstract Property<Boolean> getOffline();
 
     @Inject
-    public Installer(Project project, String name, TaskProvider<InstallerJar> jar, TaskProvider<InstallerJson> json, TaskProvider<LauncherJson> launcherJson, TaskProvider<DownloadDependency> base) {
+    public Installer(Project project, String name, TaskProvider<InstallerJar> jar, TaskProvider<InstallerJarConfig> jarConfig, TaskProvider<InstallerJson> json, TaskProvider<LauncherJson> launcherJson, TaskProvider<DownloadDependency> base) {
         this.project = project;
         this.name = name;
         this.jar = jar;
+        this.jarConfig = jarConfig;
         this.json = json;
         this.launcherJson = launcherJson;
         this.base = base;
-        this.getCi().convention(false);
+        this.getDev().convention(false);
         this.getOffline().convention(false);
     }
     public String getName() { return this.name; }
@@ -94,7 +96,7 @@ public abstract class Installer {
     public Tool tool(Object dependency, boolean transitive) {
         var gav = Util.asArtifactString(dependency);
         var tree = MinimalResolvedArtifact.from(project, gav, transitive).get();
-        this.jar.configure(task -> {
+        this.jarConfig.configure(task -> {
             for (var artifact : tree)
                 task.library(project.provider(() -> artifact), noop());
         });
@@ -132,12 +134,12 @@ public abstract class Installer {
     }
     public void library(Provider<MinimalResolvedArtifact> info, Action<LibraryInfo> action) {
         this.getJson().configure(task -> task.library(info, action));
-        this.getJar().configure(task -> task.library(info, action));
+        this.jarConfig.configure(task -> task.library(info, action));
     }
 
     public void launcherLibraries(Configuration configuration) {
         this.getLauncherJson().configure(task -> task.libraries(configuration));
-        this.getJar().configure(task -> task.libraries(MinimalResolvedArtifact.from(project, configuration)));
+        this.jarConfig.configure(task -> task.libraries(configuration));
     }
     public void launcherLibrary(String artifact) {
         launcherLibrary(artifact, noop());
@@ -162,7 +164,7 @@ public abstract class Installer {
     }
     public void launcherLibrary(Provider<MinimalResolvedArtifact> info, Action<LibraryInfo> action) {
         this.getLauncherJson().configure(task -> task.library(info, action));
-        this.getJar().configure(task -> task.library(info, action));
+        this.jarConfig.configure(task -> task.library(info, action));
     }
 
 
@@ -192,17 +194,19 @@ public abstract class Installer {
         var self = project.getProviders().provider(() -> holder.value);
 
         var base = DownloadDependency.register(project, name + "DownloadBase", Tools.INSTALLER.getModule().toString());
-        var jar = tasks.register(name + "Jar", InstallerJar.class, self);
+        var jarConfig = tasks.register(name + "JarConfig", InstallerJarConfig.class, self);
+        var jar = tasks.register(name + "Jar", InstallerJar.class);
         var json = tasks.register(name + "Json", InstallerJson.class);
         var launcherJson = tasks.register(name + "LauncherJson", LauncherJson.class);
 
         var baseDir = project.getLayout().getBuildDirectory().dir(name).get();
-        var ret = project.getObjects().newInstance(Installer.class, project, name, jar, json, launcherJson, base);
+        var ret = project.getObjects().newInstance(Installer.class, project, name, jar, jarConfig, json, launcherJson, base);
         holder.value = ret;
-        ret.getCi().convention(ext.isCi());
+        ret.getDev().convention(!ext.isCi());
 
         jar.configure(task -> {
             task.getArchiveClassifier().set(Util.kebab(name));
+            task.dependsOn(jarConfig);
 
             task.from(
                 json,

--- a/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/Installer.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/Installer.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+package net.minecraftforge.forgedev.tasks.installer;
+
+import net.minecraftforge.forgedev.ForgeDevExtension;
+import net.minecraftforge.forgedev.Tools;
+import net.minecraftforge.forgedev.legacy.tasks.DownloadDependency;
+import net.minecraftforge.forgedev.legacy.tasks.Util;
+import net.minecraftforge.forgedev.legacy.values.LibraryInfo;
+import net.minecraftforge.forgedev.legacy.values.MavenInfo;
+import net.minecraftforge.forgedev.legacy.values.MinimalResolvedArtifact;
+import net.minecraftforge.forgedev.tasks.SingleFileOutput;
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.file.DuplicatesStrategy;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.api.tasks.bundling.AbstractArchiveTask;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import javax.inject.Inject;
+import java.util.List;
+
+public abstract class Installer {
+    static final List<String> JSON_COMMENT = List.of(
+        "Please do not automate the download and installation of Forge.",
+        "Our efforts are supported by ads from the download page.",
+        "If you MUST automate this, please consider supporting the project through https://www.patreon.com/LexManos/"
+    );
+    private static final Action<?> DO_NOTHING = input -> {};
+    @SuppressWarnings("unchecked")
+    private static <T> Action<T> noop() {
+        return (Action<T>)DO_NOTHING;
+    }
+
+    private final Project project;
+    private final String name;
+    // Public facing tasks
+    private final TaskProvider<InstallerJar> jar;
+    private final TaskProvider<InstallerJson> json;
+    private final TaskProvider<LauncherJson> launcherJson;
+
+    // Implemntation details
+    private final TaskProvider<DownloadDependency> base;
+
+    @Input
+    public abstract Property<Boolean> getCi();
+    @Input
+    public abstract Property<Boolean> getOffline();
+
+    @Inject
+    public Installer(Project project, String name, TaskProvider<InstallerJar> jar, TaskProvider<InstallerJson> json, TaskProvider<LauncherJson> launcherJson, TaskProvider<DownloadDependency> base) {
+        this.project = project;
+        this.name = name;
+        this.jar = jar;
+        this.json = json;
+        this.launcherJson = launcherJson;
+        this.base = base;
+        this.getCi().convention(false);
+        this.getOffline().convention(false);
+    }
+    public String getName() { return this.name; }
+
+    public TaskProvider<InstallerJar> getJar() {
+        return this.jar;
+    }
+    public void jar(Action<? super InstallerJar> action) {
+        getJar().configure(action);
+    }
+
+    public TaskProvider<@NotNull InstallerJson> getJson() {
+        return this.json;
+    }
+    public void json(Action<? super InstallerJson> action) {
+        getJson().configure(action);
+    }
+
+    public TaskProvider<LauncherJson> getLauncherJson() {
+        return this.launcherJson;
+    }
+    public void launcherJson(Action<? super LauncherJson> action) {
+        getLauncherJson().configure(action);
+    }
+
+    public Tool tool(Object dependency) {
+        return tool(dependency, true);
+    }
+    public Tool tool(Object dependency, boolean transitive) {
+        var gav = Util.asArtifactString(dependency);
+        var tree = MinimalResolvedArtifact.from(project, gav, transitive).get();
+        this.jar.configure(task -> {
+            for (var artifact : tree)
+                task.library(project.provider(() -> artifact), noop());
+        });
+        return new Tool(gav, tree);
+    }
+
+    public void pack(TaskProvider<? extends AbstractArchiveTask> task) {
+        pack(task, noop());
+    }
+    public void pack(TaskProvider<? extends AbstractArchiveTask> task, Action<LibraryInfo> action) {
+        pack(MinimalResolvedArtifact.from(project, task), action);
+    }
+    public void pack(Provider<MinimalResolvedArtifact> info) {
+        pack(info, noop());
+    }
+    public void pack(Provider<MinimalResolvedArtifact> info, Action<LibraryInfo> action) {
+        this.getJson().configure(task -> task.library(info, action));
+        this.getJar().configure(task -> task.pack(info));
+    }
+
+    public void library(String artifact) {
+        library(artifact, noop());
+    }
+    public void library(String artifact, Action<LibraryInfo> action) {
+        library(MinimalResolvedArtifact.single(project, artifact), action);
+    }
+    public void library(TaskProvider<? extends AbstractArchiveTask> task) {
+        library(task, noop());
+    }
+    public void library(TaskProvider<? extends AbstractArchiveTask> task, Action<LibraryInfo> action) {
+        library(MinimalResolvedArtifact.from(project, task), action);
+    }
+    public void library(Provider<MinimalResolvedArtifact> info) {
+        library(info, noop());
+    }
+    public void library(Provider<MinimalResolvedArtifact> info, Action<LibraryInfo> action) {
+        this.getJson().configure(task -> task.library(info, action));
+        this.getJar().configure(task -> task.library(info, action));
+    }
+
+    public void launcherLibraries(Configuration configuration) {
+        this.getLauncherJson().configure(task -> task.libraries(configuration));
+        this.getJar().configure(task -> task.libraries(MinimalResolvedArtifact.from(project, configuration)));
+    }
+    public void launcherLibrary(String artifact) {
+        launcherLibrary(artifact, noop());
+    }
+    public void launcherLibrary(String artifact, Action<LibraryInfo> action) {
+        launcherLibrary(MinimalResolvedArtifact.single(project, artifact), action);
+    }
+    public void launcherLibrary(TaskProvider<? extends AbstractArchiveTask> task) {
+        launcherLibrary(task, noop());
+    }
+    public void launcherLibrary(TaskProvider<? extends AbstractArchiveTask> task, Action<LibraryInfo> action) {
+        launcherLibrary(MinimalResolvedArtifact.from(project, task), action);
+    }
+    public void launcherLibrary(TaskProvider<? extends SingleFileOutput> task, String classifier) {
+        launcherLibrary(task, classifier, noop());
+    }
+    public void launcherLibrary(TaskProvider<? extends SingleFileOutput> task, String classifier, Action<LibraryInfo> action) {
+        launcherLibrary(MinimalResolvedArtifact.from(MavenInfo.from(project, classifier), task.flatMap(SingleFileOutput::getOutput)), action);
+    }
+    public void launcherLibrary(Provider<MinimalResolvedArtifact> info) {
+        launcherLibrary(info, noop());
+    }
+    public void launcherLibrary(Provider<MinimalResolvedArtifact> info, Action<LibraryInfo> action) {
+        this.getLauncherJson().configure(task -> task.library(info, action));
+        this.getJar().configure(task -> task.library(info, action));
+    }
+
+
+    /// Helper to set the base installer to Forge's this is meant to make it easy to do something like:
+    /// installer {
+    ///   baseVersion = "1.0"
+    /// }
+    public void setBaseVersion(String version) {
+        this.setBase("net.minecraftforge:installer:" + version + ":fatjar");
+    }
+    public void setBase(String artifact) {
+        base.configure(task -> task.setArtifact(artifact) );
+    }
+
+    @ApiStatus.Internal
+    public static final String DEFAULT_NAME = "installer";
+
+    @ApiStatus.Internal
+    public static Installer register(Project project, ForgeDevExtension ext, String name) {
+        var tasks = project.getTasks();
+
+        // This is annoying, but this allows me to pass in a reference to Installer to the tasks so they can see each other
+        class Holder {
+            Installer value;
+        }
+        var holder = new Holder();
+        var self = project.getProviders().provider(() -> holder.value);
+
+        var base = DownloadDependency.register(project, name + "DownloadBase", Tools.INSTALLER.getModule().toString());
+        var jar = tasks.register(name + "Jar", InstallerJar.class, self);
+        var json = tasks.register(name + "Json", InstallerJson.class);
+        var launcherJson = tasks.register(name + "LauncherJson", LauncherJson.class);
+
+        var baseDir = project.getLayout().getBuildDirectory().dir(name).get();
+        var ret = project.getObjects().newInstance(Installer.class, project, name, jar, json, launcherJson, base);
+        holder.value = ret;
+        ret.getCi().convention(ext.isCi());
+
+        jar.configure(task -> {
+            task.getArchiveClassifier().set(Util.kebab(name));
+
+            task.from(
+                json,
+                launcherJson
+            );
+
+            task.from(project.zipTree(base.map(DownloadDependency::getOutput)), cfg -> {
+               cfg.setDuplicatesStrategy(DuplicatesStrategy.EXCLUDE);
+            });
+        });
+
+        json.configure(task -> {
+            task.getOutput().set(baseDir.file("installer_profile.json"));
+        });
+
+        launcherJson.configure(task -> {
+            task.getOutput().set(baseDir.file("version.json"));
+        });
+
+        return ret;
+    }
+}

--- a/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/InstallerJar.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/InstallerJar.java
@@ -4,26 +4,17 @@
  */
 package net.minecraftforge.forgedev.tasks.installer;
 
-import net.minecraftforge.forgedev.legacy.values.LibraryInfo;
 import net.minecraftforge.forgedev.legacy.values.MinimalResolvedArtifact;
-import net.minecraftforge.util.download.DownloadUtils;
-import org.gradle.api.Action;
 import org.gradle.api.file.DuplicatesStrategy;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.bundling.Zip;
 import org.jetbrains.annotations.ApiStatus;
 
 import javax.inject.Inject;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.util.List;
 
 public abstract class InstallerJar extends Zip {
-    private final Provider<Installer> installer;
-
     @Inject
-    public InstallerJar(Provider<Installer> installer) {
-        this.installer = installer;
+    public InstallerJar() {
         // We have to `set` here because the default plugin forces the conventions after the task is created
         // But since configuration is done in order, callers can override in their actions
         this.getArchiveClassifier().set("installer");
@@ -43,49 +34,5 @@ public abstract class InstallerJar extends Zip {
             });
             spec.setDuplicatesStrategy(DuplicatesStrategy.EXCLUDE);
         });
-    }
-
-    @ApiStatus.Internal
-    public void libraries(Provider<List<MinimalResolvedArtifact>> libraries) {
-        // TODO: [ForgeDev][LazyConfig] See if we can trick CopySpec into allowing an empty list
-        for (var artifact : libraries.get()) {
-            library(this.getProject().provider(() -> artifact), lib -> {});
-        }
-    }
-
-    @ApiStatus.Internal
-    public void library(Provider<MinimalResolvedArtifact> provider, Action<LibraryInfo> action) {
-        // TODO: [ForgeDev][LazyConfig] See if we can trick CopySpec into allowing an empty list
-        var info = provider.map(LibraryInfo::from).map(LibraryInfo.apply(action)).get();
-        var artifact = info.downloads().artifact();
-        var offline = installer.get().getOffline().get();
-
-        // If we are not making an offline installer, and we're on the CI don't check remote, assume we're gunna publish everything
-        if (!offline && installer.get().getCi().get()) {
-            getProject().getLogger().lifecycle("Skipping: " + artifact.path);
-            return;
-        }
-
-        // If it's an offline jar, always pack
-        var pack = offline || artifact.url.isEmpty();
-
-        // If it's not, Check if the remote
-        if (!pack) {
-            try {
-                // See if the remote hash is the same as ours
-                var remote = DownloadUtils.downloadString(artifact.url + ".sha1");
-                pack = !artifact.sha1.equals(remote);
-            } catch (FileNotFoundException e) {
-                // The file doesn't exist, Mojang's maven doesn't include them, so assume it exists if it's on there.
-                pack = !artifact.url.startsWith("https://libraries.minecraft.net/");
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        if (pack)
-            pack(provider);
-        else
-            getProject().getLogger().lifecycle("Skipping: " + artifact.path);
     }
 }

--- a/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/InstallerJar.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/InstallerJar.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+package net.minecraftforge.forgedev.tasks.installer;
+
+import net.minecraftforge.forgedev.legacy.values.LibraryInfo;
+import net.minecraftforge.forgedev.legacy.values.MinimalResolvedArtifact;
+import net.minecraftforge.util.download.DownloadUtils;
+import org.gradle.api.Action;
+import org.gradle.api.file.DuplicatesStrategy;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.bundling.Zip;
+import org.jetbrains.annotations.ApiStatus;
+
+import javax.inject.Inject;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.List;
+
+public abstract class InstallerJar extends Zip {
+    private final Provider<Installer> installer;
+
+    @Inject
+    public InstallerJar(Provider<Installer> installer) {
+        this.installer = installer;
+        // We have to `set` here because the default plugin forces the conventions after the task is created
+        // But since configuration is done in order, callers can override in their actions
+        this.getArchiveClassifier().set("installer");
+        this.getArchiveExtension().set("jar"); // We use Zip task so it doesn't overwrite the Manifest
+        // Technically this should pull from BasePluginExtension, but there is a to-do in gradle to break that so I don't care.
+        // https://github.com/gradle/gradle/blob/fb1720293a5c90a642f636843e6793555761e64e/platforms/jvm/plugins-java-base/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java#L354
+        this.getDestinationDirectory().set(getProject().getLayout().getBuildDirectory().dir("libs"));
+    }
+
+    @ApiStatus.Internal
+    public void pack(Provider<MinimalResolvedArtifact> info) {
+        this.from(info.map(MinimalResolvedArtifact::file), spec -> {
+            spec.rename( name -> {
+                var path = info.get().info().path();
+                getProject().getLogger().lifecycle("Adding: " + path);
+                return "maven/" + path;
+            });
+            spec.setDuplicatesStrategy(DuplicatesStrategy.EXCLUDE);
+        });
+    }
+
+    @ApiStatus.Internal
+    public void libraries(Provider<List<MinimalResolvedArtifact>> libraries) {
+        // TODO: [ForgeDev][LazyConfig] See if we can trick CopySpec into allowing an empty list
+        for (var artifact : libraries.get()) {
+            library(this.getProject().provider(() -> artifact), lib -> {});
+        }
+    }
+
+    @ApiStatus.Internal
+    public void library(Provider<MinimalResolvedArtifact> provider, Action<LibraryInfo> action) {
+        // TODO: [ForgeDev][LazyConfig] See if we can trick CopySpec into allowing an empty list
+        var info = provider.map(LibraryInfo::from).map(LibraryInfo.apply(action)).get();
+        var artifact = info.downloads().artifact();
+        var offline = installer.get().getOffline().get();
+
+        // If we are not making an offline installer, and we're on the CI don't check remote, assume we're gunna publish everything
+        if (!offline && installer.get().getCi().get()) {
+            getProject().getLogger().lifecycle("Skipping: " + artifact.path);
+            return;
+        }
+
+        // If it's an offline jar, always pack
+        var pack = offline || artifact.url.isEmpty();
+
+        // If it's not, Check if the remote
+        if (!pack) {
+            try {
+                // See if the remote hash is the same as ours
+                var remote = DownloadUtils.downloadString(artifact.url + ".sha1");
+                pack = !artifact.sha1.equals(remote);
+            } catch (FileNotFoundException e) {
+                // The file doesn't exist, Mojang's maven doesn't include them, so assume it exists if it's on there.
+                pack = !artifact.url.startsWith("https://libraries.minecraft.net/");
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        if (pack)
+            pack(provider);
+        else
+            getProject().getLogger().lifecycle("Skipping: " + artifact.path);
+    }
+}

--- a/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/InstallerJarConfig.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/InstallerJarConfig.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+package net.minecraftforge.forgedev.tasks.installer;
+
+import net.minecraftforge.forgedev.legacy.values.LibraryInfo;
+import net.minecraftforge.forgedev.legacy.values.MinimalResolvedArtifact;
+import net.minecraftforge.util.download.DownloadUtils;
+import org.gradle.api.Action;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DuplicatesStrategy;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.TaskAction;
+import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.Nullable;
+
+import javax.inject.Inject;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+@ApiStatus.Internal
+public abstract class InstallerJarConfig extends DefaultTask {
+    private final Provider<Installer> installer;
+
+    @InputFiles abstract ConfigurableFileCollection getInput();
+    @Input abstract Property<Boolean> getDev();
+    @Input abstract Property<Boolean> getOffline();
+    @Input abstract ListProperty<MinimalResolvedArtifact> getLibraries();
+    private final Map<Provider<String>, Action<LibraryInfo>> actions = new IdentityHashMap<>();
+
+    @Inject
+    public InstallerJarConfig(Provider<Installer> installer) {
+        this.installer = installer;
+        this.getDev().convention(installer.flatMap(Installer::getDev));
+        this.getOffline().convention(installer.flatMap(Installer::getOffline));
+    }
+
+    @TaskAction
+    protected void exec() {
+        var actions = new HashMap<String, Action<LibraryInfo>>();
+        for (var entry : this.actions.entrySet()) {
+            actions.put(entry.getKey().get(), entry.getValue());
+        }
+
+        for (var artifact :  getLibraries().get()) {
+            var action = actions.get(artifact.info().name());
+            pack(artifact, action);
+        }
+    }
+
+    @ApiStatus.Internal
+    public void libraries(Configuration config) {
+        this.getInput().from(config);
+        this.getLibraries().addAll(MinimalResolvedArtifact.from(getProject(), config));
+    }
+
+    @ApiStatus.Internal
+    public void library(Provider<MinimalResolvedArtifact> info, Action<LibraryInfo> action) {
+        this.getInput().from(info.map(MinimalResolvedArtifact::file));
+        this.getLibraries().add(info);
+        actions.put(info.map(artifact -> artifact.info().name()), action);
+    }
+
+    private void pack(MinimalResolvedArtifact resolved, @Nullable Action<LibraryInfo> action) {
+        var info = LibraryInfo.from(resolved);
+        if (action != null)
+            action.execute(info);
+
+        var artifact = info.downloads().artifact();
+        var offline = getOffline().get();
+
+        // If we are not making an offline installer, and we're on the CI don't check remote, assume we're gunna publish everything
+        if (!offline && !getDev().get()) {
+            //getProject().getLogger().lifecycle("Skipping: " + artifact.path);
+            return;
+        }
+
+        // If it's an offline jar, always pack
+        var pack = offline || artifact.url.isEmpty();
+
+        // If it's not, Check if the remote
+        if (!pack) {
+            try {
+                // See if the remote hash is the same as ours
+                var remote = DownloadUtils.downloadString(artifact.url + ".sha1");
+                pack = !artifact.sha1.equals(remote);
+            } catch (FileNotFoundException e) {
+                // The file doesn't exist, Mojang's maven doesn't include them, so assume it exists if it's on there.
+                pack = !artifact.url.startsWith("https://libraries.minecraft.net/");
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        if (!pack) {
+            //getProject().getLogger().lifecycle("Skipping: " + artifact.path);
+            return;
+        }
+
+        this.installer.get().getJar().configure(task -> {
+            task.from(resolved.file(), spec -> {
+                spec.rename(name -> {
+                    var path = resolved.info().path();
+                    getProject().getLogger().lifecycle("Adding: " + path);
+                    return "maven/" + path;
+                });
+                spec.setDuplicatesStrategy(DuplicatesStrategy.EXCLUDE);
+            });
+        });
+    }
+}

--- a/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/InstallerJarConfig.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/InstallerJarConfig.java
@@ -4,6 +4,7 @@
  */
 package net.minecraftforge.forgedev.tasks.installer;
 
+import net.minecraftforge.forgedev.legacy.tasks.DownloadDependency;
 import net.minecraftforge.forgedev.legacy.values.LibraryInfo;
 import net.minecraftforge.forgedev.legacy.values.MinimalResolvedArtifact;
 import net.minecraftforge.util.download.DownloadUtils;
@@ -18,6 +19,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.TaskProvider;
 import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.Nullable;
 
@@ -25,12 +27,14 @@ import javax.inject.Inject;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Map;
 
 @ApiStatus.Internal
 public abstract class InstallerJarConfig extends DefaultTask {
     private final Provider<Installer> installer;
+    private final TaskProvider<DownloadDependency> base;
 
     @InputFiles abstract ConfigurableFileCollection getInput();
     @Input abstract Property<Boolean> getDev();
@@ -39,22 +43,39 @@ public abstract class InstallerJarConfig extends DefaultTask {
     private final Map<Provider<String>, Action<LibraryInfo>> actions = new IdentityHashMap<>();
 
     @Inject
-    public InstallerJarConfig(Provider<Installer> installer) {
+    public InstallerJarConfig(Provider<Installer> installer, TaskProvider<DownloadDependency> base) {
         this.installer = installer;
+        this.base = base;
         this.getDev().convention(installer.flatMap(Installer::getDev));
         this.getOffline().convention(installer.flatMap(Installer::getOffline));
     }
 
     @TaskAction
     protected void exec() {
+        // Add the base here, so that the buildscript configuration runs first
+        installer.get().jar( task -> {
+            task.from(getProject().zipTree(base.map(DownloadDependency::getOutput)), cfg -> {
+                cfg.setDuplicatesStrategy(DuplicatesStrategy.EXCLUDE);
+            });
+        });
+
         var actions = new HashMap<String, Action<LibraryInfo>>();
         for (var entry : this.actions.entrySet()) {
             actions.put(entry.getKey().get(), entry.getValue());
         }
 
-        for (var artifact :  getLibraries().get()) {
+        var seen = new HashSet<String>();
+        for (var artifact : getLibraries().get()) {
+            var info = LibraryInfo.from(artifact);
             var action = actions.get(artifact.info().name());
-            pack(artifact, action);
+            if (action != null)
+                action.execute(info);
+
+            // Check for duplicates without pinging remote servers
+            if (!seen.add(info.downloads().artifact().path))
+                continue;
+
+            pack(artifact, info);
         }
     }
 
@@ -71,11 +92,7 @@ public abstract class InstallerJarConfig extends DefaultTask {
         actions.put(info.map(artifact -> artifact.info().name()), action);
     }
 
-    private void pack(MinimalResolvedArtifact resolved, @Nullable Action<LibraryInfo> action) {
-        var info = LibraryInfo.from(resolved);
-        if (action != null)
-            action.execute(info);
-
+    private void pack(MinimalResolvedArtifact resolved, LibraryInfo info) {
         var artifact = info.downloads().artifact();
         var offline = getOffline().get();
 
@@ -110,9 +127,8 @@ public abstract class InstallerJarConfig extends DefaultTask {
         this.installer.get().getJar().configure(task -> {
             task.from(resolved.file(), spec -> {
                 spec.rename(name -> {
-                    var path = resolved.info().path();
-                    getProject().getLogger().lifecycle("Adding: " + path);
-                    return "maven/" + path;
+                    getProject().getLogger().lifecycle("Adding: " + artifact.path);
+                    return "maven/" + artifact.path;
                 });
                 spec.setDuplicatesStrategy(DuplicatesStrategy.EXCLUDE);
             });

--- a/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/InstallerJarConfig.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/InstallerJarConfig.java
@@ -11,6 +11,7 @@ import net.minecraftforge.util.download.DownloadUtils;
 import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.file.ArchiveOperations;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DuplicatesStrategy;
 import org.gradle.api.provider.ListProperty;
@@ -21,7 +22,6 @@ import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.TaskProvider;
 import org.jetbrains.annotations.ApiStatus;
-import org.jspecify.annotations.Nullable;
 
 import javax.inject.Inject;
 import java.io.FileNotFoundException;
@@ -42,6 +42,8 @@ public abstract class InstallerJarConfig extends DefaultTask {
     @Input abstract ListProperty<MinimalResolvedArtifact> getLibraries();
     private final Map<Provider<String>, Action<LibraryInfo>> actions = new IdentityHashMap<>();
 
+    @Inject protected abstract ArchiveOperations getArchiveOperations();
+
     @Inject
     public InstallerJarConfig(Provider<Installer> installer, TaskProvider<DownloadDependency> base) {
         this.installer = installer;
@@ -54,10 +56,16 @@ public abstract class InstallerJarConfig extends DefaultTask {
     protected void exec() {
         // Add the base here, so that the buildscript configuration runs first
         installer.get().jar( task -> {
-            task.from(getProject().zipTree(base.map(DownloadDependency::getOutput)), cfg -> {
+            task.from(getArchiveOperations().zipTree(base.map(DownloadDependency::getOutput)), cfg -> {
                 cfg.setDuplicatesStrategy(DuplicatesStrategy.EXCLUDE);
             });
         });
+
+        // If we are not making an offline installer, and we're on the CI don't check remote, assume we're gunna publish everything
+        if (!getOffline().get() && !getDev().get()) {
+            //getLogger().lifecycle("Skipping: " + artifact.path);
+            return;
+        }
 
         var actions = new HashMap<String, Action<LibraryInfo>>();
         for (var entry : this.actions.entrySet()) {
@@ -65,6 +73,7 @@ public abstract class InstallerJarConfig extends DefaultTask {
         }
 
         var seen = new HashSet<String>();
+        // TODO: [ForgeDev][Optimization] Thread this, as it takes 30s/build because of all the network requests
         for (var artifact : getLibraries().get()) {
             var info = LibraryInfo.from(artifact);
             var action = actions.get(artifact.info().name());
@@ -94,16 +103,9 @@ public abstract class InstallerJarConfig extends DefaultTask {
 
     private void pack(MinimalResolvedArtifact resolved, LibraryInfo info) {
         var artifact = info.downloads().artifact();
-        var offline = getOffline().get();
 
-        // If we are not making an offline installer, and we're on the CI don't check remote, assume we're gunna publish everything
-        if (!offline && !getDev().get()) {
-            //getProject().getLogger().lifecycle("Skipping: " + artifact.path);
-            return;
-        }
-
-        // If it's an offline jar, always pack
-        var pack = offline || artifact.url.isEmpty();
+        // If it's an offline jar, or generated artifact always pack
+        var pack = getOffline().get() || artifact.url.isEmpty();
 
         // If it's not, Check if the remote
         if (!pack) {
@@ -120,14 +122,14 @@ public abstract class InstallerJarConfig extends DefaultTask {
         }
 
         if (!pack) {
-            //getProject().getLogger().lifecycle("Skipping: " + artifact.path);
+            //getLogger().lifecycle("Skipping: " + artifact.path);
             return;
         }
 
         this.installer.get().getJar().configure(task -> {
             task.from(resolved.file(), spec -> {
                 spec.rename(name -> {
-                    getProject().getLogger().lifecycle("Adding: " + artifact.path);
+                    getLogger().lifecycle("Adding: " + artifact.path);
                     return "maven/" + artifact.path;
                 });
                 spec.setDuplicatesStrategy(DuplicatesStrategy.EXCLUDE);

--- a/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/InstallerJarConfig.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/InstallerJarConfig.java
@@ -36,10 +36,10 @@ public abstract class InstallerJarConfig extends DefaultTask {
     private final Provider<Installer> installer;
     private final TaskProvider<DownloadDependency> base;
 
-    @InputFiles abstract ConfigurableFileCollection getInput();
-    @Input abstract Property<Boolean> getDev();
-    @Input abstract Property<Boolean> getOffline();
-    @Input abstract ListProperty<MinimalResolvedArtifact> getLibraries();
+    @InputFiles public abstract ConfigurableFileCollection getInput();
+    @Input public abstract Property<Boolean> getDev();
+    @Input public abstract Property<Boolean> getOffline();
+    @Input public abstract ListProperty<MinimalResolvedArtifact> getLibraries();
     private final Map<Provider<String>, Action<LibraryInfo>> actions = new IdentityHashMap<>();
 
     @Inject protected abstract ArchiveOperations getArchiveOperations();

--- a/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/InstallerJson.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/InstallerJson.java
@@ -39,7 +39,10 @@ import java.util.Map;
 import java.util.Set;
 
 public abstract class InstallerJson extends DefaultTask {
-    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+    private static final Gson GSON = new GsonBuilder()
+        .disableHtmlEscaping()
+        .setPrettyPrinting()
+        .create();
 
     protected abstract @Inject ProviderFactory getProviders();
     protected abstract @Inject ObjectFactory getObjects();

--- a/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/InstallerJson.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/InstallerJson.java
@@ -47,26 +47,26 @@ public abstract class InstallerJson extends DefaultTask {
     protected abstract @Inject ProviderFactory getProviders();
     protected abstract @Inject ObjectFactory getObjects();
 
-    @OutputFile abstract RegularFileProperty getOutput();
+    @OutputFile public abstract RegularFileProperty getOutput();
 
-    @InputFiles abstract ConfigurableFileCollection getInput();
-    @InputFile @Optional abstract RegularFileProperty getIcon();
-    @Input abstract Property<String> getLauncherJsonName();
-    @Input abstract Property<String> getLogo();
-    @Input abstract Property<String> getMirrors();
-    @Input abstract Property<String> getWelcome();
-    @Input abstract Property<String> getProfileName();
-    @Input abstract Property<String> getProfileVersion();
-    @Input abstract Property<String> getExecutablePath();
-    @Input abstract Property<String> getMinecraft();
-    @Input abstract Property<String> getMinecraftServerPath();
+    @InputFiles public abstract ConfigurableFileCollection getInput();
+    @InputFile @Optional public abstract RegularFileProperty getIcon();
+    @Input public abstract Property<String> getLauncherJsonName();
+    @Input public abstract Property<String> getLogo();
+    @Input public abstract Property<String> getMirrors();
+    @Input public abstract Property<String> getWelcome();
+    @Input public abstract Property<String> getProfileName();
+    @Input public abstract Property<String> getProfileVersion();
+    @Input public abstract Property<String> getExecutablePath();
+    @Input public abstract Property<String> getMinecraft();
+    @Input public abstract Property<String> getMinecraftServerPath();
 
-    @Input abstract Property<Boolean> getHideExtract();
-    @Input abstract Property<Boolean> getHideClient();
-    @Input abstract Property<Boolean> getHideServer();
+    @Input public abstract Property<Boolean> getHideExtract();
+    @Input public abstract Property<Boolean> getHideClient();
+    @Input public abstract Property<Boolean> getHideServer();
 
-    @Input @Optional abstract MapProperty<String, Data> getData();
-    @Input @Optional abstract ListProperty<Step> getSteps();
+    @Input @Optional public abstract MapProperty<String, Data> getData();
+    @Input @Optional public abstract ListProperty<Step> getSteps();
 
     private final Set<Provider<LibraryInfo>> extraLibraries = new LinkedHashSet<>();
 

--- a/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/InstallerJson.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/InstallerJson.java
@@ -4,7 +4,8 @@
  */
 package net.minecraftforge.forgedev.tasks.installer;
 
-import groovy.json.JsonBuilder;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import net.minecraftforge.forgedev.legacy.tasks.Util;
 import net.minecraftforge.forgedev.legacy.values.LibraryInfo;
 import net.minecraftforge.forgedev.legacy.values.MinimalResolvedArtifact;
@@ -38,6 +39,8 @@ import java.util.Map;
 import java.util.Set;
 
 public abstract class InstallerJson extends DefaultTask {
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+
     protected abstract @Inject ProviderFactory getProviders();
     protected abstract @Inject ObjectFactory getObjects();
 
@@ -190,7 +193,7 @@ public abstract class InstallerJson extends DefaultTask {
         json.put("welcome",  getWelcome().get());
 
         var output = getOutput().get().getAsFile().toPath();
-        var jsonData = new JsonBuilder(json).toPrettyString();
+        var jsonData = GSON.toJson(json);
         Files.writeString(output, jsonData);
     }
 }

--- a/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/InstallerJson.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/InstallerJson.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+package net.minecraftforge.forgedev.tasks.installer;
+
+import groovy.json.JsonBuilder;
+import net.minecraftforge.forgedev.legacy.tasks.Util;
+import net.minecraftforge.forgedev.legacy.values.LibraryInfo;
+import net.minecraftforge.forgedev.legacy.values.MinimalResolvedArtifact;
+import net.minecraftforge.forgedev.tasks.installer.steps.Extract;
+import net.minecraftforge.forgedev.tasks.installer.steps.ExtractBundle;
+import net.minecraftforge.forgedev.tasks.installer.steps.Step;
+import org.gradle.api.Action;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.tasks.*;
+import org.gradle.api.tasks.bundling.AbstractArchiveTask;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+public abstract class InstallerJson extends DefaultTask {
+    protected abstract @Inject ProviderFactory getProviders();
+    protected abstract @Inject ObjectFactory getObjects();
+
+    @OutputFile abstract RegularFileProperty getOutput();
+
+    @InputFiles abstract ConfigurableFileCollection getInput();
+    @InputFile @Optional abstract RegularFileProperty getIcon();
+    @Input abstract Property<String> getLauncherJsonName();
+    @Input abstract Property<String> getLogo();
+    @Input abstract Property<String> getMirrors();
+    @Input abstract Property<String> getWelcome();
+    @Input abstract Property<String> getProfileName();
+    @Input abstract Property<String> getProfileVersion();
+    @Input abstract Property<String> getExecutablePath();
+    @Input abstract Property<String> getMinecraft();
+    @Input abstract Property<String> getMinecraftServerPath();
+
+    @Input abstract Property<Boolean> getHideExtract();
+    @Input abstract Property<Boolean> getHideClient();
+    @Input abstract Property<Boolean> getHideServer();
+
+    @Input @Optional abstract MapProperty<String, Data> getData();
+    @Input @Optional abstract ListProperty<Step> getSteps();
+
+    private final Set<Provider<LibraryInfo>> extraLibraries = new LinkedHashSet<>();
+
+    @Inject
+    public InstallerJson() {
+        getOutput().convention(getProject().getLayout().getBuildDirectory().file("libs/install_profile.json"));
+
+        getLauncherJsonName().convention("/version.json");
+        getLogo().convention("/big_logo.png");
+        getMirrors().convention("https://files.minecraftforge.net/mirrors-2.0.json");
+        getWelcome().convention("Welcome to the " + Util.capitalize(getProject().getName()) + " installer.");
+        getMinecraftServerPath().convention("{LIBRARY_DIR}/net/minecraft/server/{MINECRAFT_VERSION}/server-{MINECRAFT_VERSION}-bundled.jar");
+        getProfileName().convention(getProject().getName());
+
+        getHideExtract().convention(true);
+        getHideClient().convention(false);
+        getHideServer().convention(false);
+    }
+
+    public void executable(TaskProvider<? extends AbstractArchiveTask> task) {
+        var info = MinimalResolvedArtifact.from(this.getProject(), task);
+        this.getExecutablePath().set(info.map(i -> i.info().name()));
+    }
+
+    public void library(Provider<MinimalResolvedArtifact> info, Action<LibraryInfo> action) {
+        this.getInput().from(info.map(MinimalResolvedArtifact::file));
+        this.extraLibraries.add(info.map(LibraryInfo::from).map(LibraryInfo.apply(action)));
+    }
+
+    private <R extends Step> R step(Class<R> cls, Tool tool, Action<? super R> action) {
+        var ret = this.getObjects().newInstance(cls, tool);
+        this.getInput().from(tool.getArtifacts().stream().map(MinimalResolvedArtifact::file).toList());
+        action.execute(ret);
+        return ret;
+    }
+
+    public Step step(Tool tool, Action<? super Step> action) {
+        return step(Step.class, tool, action);
+    }
+    public Extract extract(Tool tool, Action<? super Extract> action) {
+        return step(Extract.class, tool, action);
+    }
+    public ExtractBundle extractBundle(Tool tool, Action<? super ExtractBundle> action) {
+        return step(ExtractBundle.class, tool, action);
+    }
+
+    public record Data(String client, String server) implements Serializable {}
+
+    public void data(String key, String client, String server) {
+        this.getData().put(key, new Data(client, server));
+    }
+
+    public void data(String key, RegularFileProperty client, RegularFileProperty server) {
+        this.getData().put(key, client.zip(server, (l, r) -> new Data(
+            "'" + Util.sha1(client.get().getAsFile()) + "'",
+            "'" + Util.sha1(server.get().getAsFile()) + "'"
+        )));
+    }
+
+    @TaskAction
+    protected void exec() throws IOException {
+        var libraries = new ArrayList<LibraryInfo>();
+        var json = new LinkedHashMap<String, Object>();
+        json.put("_comment", Installer.JSON_COMMENT);
+        json.put("spec", 1);
+        if (getHideExtract().getOrElse(false))
+            json.put("hideExtract", true);
+        if (getHideClient().getOrElse(false))
+            json.put("hideClient", true);
+        if (getHideServer().getOrElse(false))
+            json.put("hideServer", true);
+        json.put("profile", getProfileName().get());
+        json.put("version", getProfileVersion().get());
+        json.put("path", getExecutablePath().get());
+        json.put("minecraft", getMinecraft().get());
+        json.put("serverJarPath", getMinecraftServerPath().get());
+
+        if (getData().isPresent() && !getData().get().isEmpty())
+            json.put("data", getData().get());
+
+        if (getSteps().isPresent() && !getSteps().get().isEmpty()) {
+            var processors = new ArrayList<Map<String, Object>>();
+            json.put("processors", processors);
+            for (var step : getSteps().get()) {
+                var data = new LinkedHashMap<String, Object>();
+                if (!step.sides.isEmpty())
+                    data.put("sides", step.sides);
+
+                var tool = step.getTool();
+                data.put("jar", tool.getJar());
+                if (!tool.getArtifacts().isEmpty()) {
+                    var classpath = new ArrayList<String>();
+                    for (var info : LibraryInfo.from(tool.getArtifacts()).values()) {
+                        libraries.add(info);
+                        if (!tool.getJar().equals(info.name()))
+                            classpath.add(info.name());
+                    }
+                    data.put("classpath", classpath);
+                }
+                data.put("args", step.getArgs());
+                if (!step.getOutputs().isEmpty())
+                    data.put("outputs", step.getOutputs());
+                processors.add(data);
+            }
+        }
+
+        for (var library : this.extraLibraries) {
+            var info = library.get();
+            libraries.add(info);
+        }
+
+        var seen = new HashSet<String>();
+        libraries.sort(Comparator.comparing(LibraryInfo::name));
+        libraries.removeIf(l -> !seen.add(l.name()));
+        json.put("libraries", libraries);
+
+        var icon = getIcon().getOrNull();
+        if (icon != null) {
+            var data = Files.readAllBytes(icon.getAsFile().toPath());
+            var base64 = Base64.getEncoder().encodeToString(data);
+            json.put("icon", "data:image/png;base64," + base64);
+        }
+        json.put("json", getLauncherJsonName().get());
+        json.put("logo",  getLogo().get());
+        if (!getMirrors().get().isEmpty())
+            json.put("mirrorList", getMirrors().get());
+        json.put("welcome",  getWelcome().get());
+
+        var output = getOutput().get().getAsFile().toPath();
+        var jsonData = new JsonBuilder(json).toPrettyString();
+        Files.writeString(output, jsonData);
+    }
+}

--- a/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/LauncherJson.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/LauncherJson.java
@@ -8,7 +8,9 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import net.minecraftforge.forgedev.legacy.tasks.Util;
 import net.minecraftforge.forgedev.legacy.values.LibraryInfo;
+import net.minecraftforge.forgedev.legacy.values.MavenInfo;
 import net.minecraftforge.forgedev.legacy.values.MinimalResolvedArtifact;
+import net.minecraftforge.forgedev.tasks.SingleFileOutput;
 import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.Configuration;
@@ -24,6 +26,7 @@ import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.TaskProvider;
 import org.jetbrains.annotations.ApiStatus;
 
 import javax.inject.Inject;
@@ -85,6 +88,16 @@ public abstract class LauncherJson extends DefaultTask {
     public void library(Provider<MinimalResolvedArtifact> info, Action<LibraryInfo> action) {
         this.getInput().from(info.map(MinimalResolvedArtifact::file));
         this.getLibraries().add(info.map(LibraryInfo::from).map(LibraryInfo.apply(action)));
+    }
+
+    public void generated(TaskProvider<? extends SingleFileOutput> task, String classifier) {
+        generated(task, classifier, t -> {});
+    }
+    public void generated(TaskProvider<? extends SingleFileOutput> task, String classifier, Action<LibraryInfo> action) {
+        library(MinimalResolvedArtifact.from(MavenInfo.from(getProject(), classifier), task.flatMap(SingleFileOutput::getOutput)), info -> {
+            action.execute(info);
+            info.downloads().artifact().url = "";
+        });
     }
 
     @TaskAction

--- a/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/LauncherJson.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/LauncherJson.java
@@ -83,7 +83,6 @@ public abstract class LauncherJson extends DefaultTask {
     }
     @ApiStatus.Internal
     public void library(Provider<MinimalResolvedArtifact> info, Action<LibraryInfo> action) {
-        getLogger().lifecycle("Library: " + info);
         this.getInput().from(info.map(MinimalResolvedArtifact::file));
         this.getLibraries().add(info.map(LibraryInfo::from).map(LibraryInfo.apply(action)));
     }

--- a/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/LauncherJson.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/LauncherJson.java
@@ -4,7 +4,8 @@
  */
 package net.minecraftforge.forgedev.tasks.installer;
 
-import groovy.json.JsonBuilder;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import net.minecraftforge.forgedev.legacy.tasks.Util;
 import net.minecraftforge.forgedev.legacy.values.LibraryInfo;
 import net.minecraftforge.forgedev.legacy.values.MinimalResolvedArtifact;
@@ -35,6 +36,8 @@ import java.util.List;
 import java.util.Map;
 
 public abstract class LauncherJson extends DefaultTask {
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+
     protected abstract @Inject ProviderFactory getProviders();
     protected abstract @Inject ObjectFactory getObjects();
 
@@ -106,7 +109,7 @@ public abstract class LauncherJson extends DefaultTask {
         getLogger().lifecycle("Launcher Json " + json.toString());
         var output = getOutput().get().getAsFile().toPath();
         getLogger().lifecycle("Launcher File " + output.toString());
-        var jsonData = new JsonBuilder(json).toPrettyString();
+        var jsonData = GSON.toJson(json);
         getLogger().lifecycle("Launcher Written");
         Files.writeString(output, jsonData);
     }

--- a/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/LauncherJson.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/LauncherJson.java
@@ -30,13 +30,17 @@ import javax.inject.Inject;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 public abstract class LauncherJson extends DefaultTask {
-    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+    private static final Gson GSON = new GsonBuilder()
+        .disableHtmlEscaping()
+        .setPrettyPrinting()
+        .create();
 
     protected abstract @Inject ProviderFactory getProviders();
     protected abstract @Inject ObjectFactory getObjects();
@@ -53,6 +57,9 @@ public abstract class LauncherJson extends DefaultTask {
     @Input @Optional abstract ListProperty<Object> getGameArgs();
     @Input @Optional abstract ListProperty<Object> getJvmArgs();
     @Input abstract ListProperty<LibraryInfo> getLibraries();
+    @Input abstract Property<Boolean> getSortLibraries();
+    @Input abstract Property<Boolean> getLibrariesLast();
+    @Input abstract Property<Boolean> getDuplicateLibraries();
 
     @Inject
     public LauncherJson() {
@@ -64,7 +71,9 @@ public abstract class LauncherJson extends DefaultTask {
         getReleaseTime().convention(timestamp);
         getType().convention("release");
         getMainClass().convention("main");
-
+        getSortLibraries().convention(true);
+        getLibrariesLast().convention(true);
+        getDuplicateLibraries().convention(false);
     }
 
     @ApiStatus.Internal
@@ -74,6 +83,7 @@ public abstract class LauncherJson extends DefaultTask {
     }
     @ApiStatus.Internal
     public void library(Provider<MinimalResolvedArtifact> info, Action<LibraryInfo> action) {
+        getLogger().lifecycle("Library: " + info);
         this.getInput().from(info.map(MinimalResolvedArtifact::file));
         this.getLibraries().add(info.map(LibraryInfo::from).map(LibraryInfo.apply(action)));
     }
@@ -89,8 +99,42 @@ public abstract class LauncherJson extends DefaultTask {
             json.put("inheritsFrom", getInheritsFrom().get());
         json.put("type", getType().get());
         json.put("logging", Map.of()); // Hardcoded for now, if we ever wanna move to remotely hosted log configs we could
-        json.put("mainClass", getMainClass().orElse(""));
+        json.put("mainClass", getMainClass().getOrElse(""));
 
+        if (!getLibrariesLast().get())
+            addLibraries(json);
+
+        addArgs(json);
+
+        if (getLibrariesLast().get())
+            addLibraries(json);
+
+        var output = getOutput().get().getAsFile().toPath();
+        var jsonData = GSON.toJson(json);
+        Files.writeString(output, jsonData);
+    }
+
+    private void addLibraries(Map<String, Object> json) {
+        var libraries = new ArrayList<>(this.getLibraries().get());
+
+        // Older versions didn't de-duplicate, so our 'bootstrap' config got added twice.
+        if (!getDuplicateLibraries().get()) {
+            var seen = new HashSet<String>();
+            libraries.removeIf(l -> !seen.add(l.name()));
+        }
+
+        // Classpath order doesn't matter in anything that works in the JPMS.
+        // Anything 1.13+ And Gradle's resolution of dependencies is not the same order as their old api.
+        // It makes this hard to diff against
+        // So lets sort by name and call it good
+        if (getSortLibraries().get())
+            libraries.sort(Comparator.comparing(LibraryInfo::name));
+
+        json.put("libraries", libraries);
+    }
+
+    private void addArgs(Map<String, Object> json) {
+        // This is below libraries for legacy diffing, It doesn't matter
         // I could model out this and add support for rules and shit.. but I dont want to
         var args = new LinkedHashMap<String, List<Object>>();
         if (getGameArgs().isPresent())
@@ -99,18 +143,5 @@ public abstract class LauncherJson extends DefaultTask {
             args.put("jvm",  getJvmArgs().get());
         if (!args.isEmpty())
             json.put("arguments", args);
-
-        var libraries = new ArrayList<>(this.getLibraries().get());
-        var seen = new HashSet<String>();
-        //libraries.sort(Comparator.comparing(LibraryInfo::name));
-        libraries.removeIf(l -> !seen.add(l.name()));
-        json.put("libraries", libraries);
-
-        getLogger().lifecycle("Launcher Json " + json.toString());
-        var output = getOutput().get().getAsFile().toPath();
-        getLogger().lifecycle("Launcher File " + output.toString());
-        var jsonData = GSON.toJson(json);
-        getLogger().lifecycle("Launcher Written");
-        Files.writeString(output, jsonData);
     }
 }

--- a/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/LauncherJson.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/LauncherJson.java
@@ -48,21 +48,21 @@ public abstract class LauncherJson extends DefaultTask {
     protected abstract @Inject ProviderFactory getProviders();
     protected abstract @Inject ObjectFactory getObjects();
 
-    @OutputFile abstract RegularFileProperty getOutput();
+    @OutputFile public abstract RegularFileProperty getOutput();
 
-    @InputFiles abstract ConfigurableFileCollection getInput();
-    @Input abstract Property<String> getTimestamp();
-    @Input abstract Property<String> getReleaseTime();
-    @Input abstract Property<String> getId();
-    @Input @Optional abstract Property<String> getInheritsFrom();
-    @Input abstract Property<String> getType();
-    @Input @Optional abstract Property<String> getMainClass();
-    @Input @Optional abstract ListProperty<Object> getGameArgs();
-    @Input @Optional abstract ListProperty<Object> getJvmArgs();
-    @Input abstract ListProperty<LibraryInfo> getLibraries();
-    @Input abstract Property<Boolean> getSortLibraries();
-    @Input abstract Property<Boolean> getLibrariesLast();
-    @Input abstract Property<Boolean> getDuplicateLibraries();
+    @InputFiles public abstract ConfigurableFileCollection getInput();
+    @Input public abstract Property<String> getTimestamp();
+    @Input public abstract Property<String> getReleaseTime();
+    @Input public abstract Property<String> getId();
+    @Input @Optional public abstract Property<String> getInheritsFrom();
+    @Input public abstract Property<String> getType();
+    @Input @Optional public abstract Property<String> getMainClass();
+    @Input @Optional public abstract ListProperty<Object> getGameArgs();
+    @Input @Optional public abstract ListProperty<Object> getJvmArgs();
+    @Input public abstract ListProperty<LibraryInfo> getLibraries();
+    @Input public abstract Property<Boolean> getSortLibraries();
+    @Input public abstract Property<Boolean> getLibrariesLast();
+    @Input public abstract Property<Boolean> getDuplicateLibraries();
 
     @Inject
     public LauncherJson() {

--- a/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/LauncherJson.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/LauncherJson.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+package net.minecraftforge.forgedev.tasks.installer;
+
+import groovy.json.JsonBuilder;
+import net.minecraftforge.forgedev.legacy.tasks.Util;
+import net.minecraftforge.forgedev.legacy.values.LibraryInfo;
+import net.minecraftforge.forgedev.legacy.values.MinimalResolvedArtifact;
+import org.gradle.api.Action;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+import org.jetbrains.annotations.ApiStatus;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public abstract class LauncherJson extends DefaultTask {
+    protected abstract @Inject ProviderFactory getProviders();
+    protected abstract @Inject ObjectFactory getObjects();
+
+    @OutputFile abstract RegularFileProperty getOutput();
+
+    @InputFiles abstract ConfigurableFileCollection getInput();
+    @Input abstract Property<String> getTimestamp();
+    @Input abstract Property<String> getReleaseTime();
+    @Input abstract Property<String> getId();
+    @Input @Optional abstract Property<String> getInheritsFrom();
+    @Input abstract Property<String> getType();
+    @Input @Optional abstract Property<String> getMainClass();
+    @Input @Optional abstract ListProperty<Object> getGameArgs();
+    @Input @Optional abstract ListProperty<Object> getJvmArgs();
+    @Input abstract ListProperty<LibraryInfo> getLibraries();
+
+    @Inject
+    public LauncherJson() {
+        getOutput().convention(getProject().getLayout().getBuildDirectory().file("libs/version.json"));
+
+        // TODO: [ForgeDev][Reproduceable] Add helper to get timestamp from latest git commit
+        var timestamp = Util.iso8601Now();
+        getTimestamp().convention(timestamp);
+        getReleaseTime().convention(timestamp);
+        getType().convention("release");
+        getMainClass().convention("main");
+
+    }
+
+    @ApiStatus.Internal
+    public void libraries(Configuration config) {
+        this.getInput().from(config);
+        this.getLibraries().addAll(MinimalResolvedArtifact.from(getProject(), config).map(LibraryInfo::toList));
+    }
+    @ApiStatus.Internal
+    public void library(Provider<MinimalResolvedArtifact> info, Action<LibraryInfo> action) {
+        this.getInput().from(info.map(MinimalResolvedArtifact::file));
+        this.getLibraries().add(info.map(LibraryInfo::from).map(LibraryInfo.apply(action)));
+    }
+
+    @TaskAction
+    protected void exec() throws IOException {
+        var json = new LinkedHashMap<String, Object>();
+        json.put("_comment", Installer.JSON_COMMENT);
+        json.put("id", getId().get());
+        json.put("time", getTimestamp().get());
+        json.put("releaseTime", getReleaseTime().get());
+        if (getInheritsFrom().isPresent())
+            json.put("inheritsFrom", getInheritsFrom().get());
+        json.put("type", getType().get());
+        json.put("logging", Map.of()); // Hardcoded for now, if we ever wanna move to remotely hosted log configs we could
+        json.put("mainClass", getMainClass().orElse(""));
+
+        // I could model out this and add support for rules and shit.. but I dont want to
+        var args = new LinkedHashMap<String, List<Object>>();
+        if (getGameArgs().isPresent())
+            args.put("game",  getGameArgs().get());
+        if (getJvmArgs().isPresent())
+            args.put("jvm",  getJvmArgs().get());
+        if (!args.isEmpty())
+            json.put("arguments", args);
+
+        var libraries = new ArrayList<>(this.getLibraries().get());
+        var seen = new HashSet<String>();
+        //libraries.sort(Comparator.comparing(LibraryInfo::name));
+        libraries.removeIf(l -> !seen.add(l.name()));
+        json.put("libraries", libraries);
+
+        getLogger().lifecycle("Launcher Json " + json.toString());
+        var output = getOutput().get().getAsFile().toPath();
+        getLogger().lifecycle("Launcher File " + output.toString());
+        var jsonData = new JsonBuilder(json).toPrettyString();
+        getLogger().lifecycle("Launcher Written");
+        Files.writeString(output, jsonData);
+    }
+}

--- a/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/Tool.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/Tool.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+package net.minecraftforge.forgedev.tasks.installer;
+
+import net.minecraftforge.forgedev.legacy.values.MinimalResolvedArtifact;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.io.Serializable;
+import java.util.List;
+
+public class Tool implements Serializable {
+    private final String jar;
+    private final List<MinimalResolvedArtifact> classpath;
+
+    public Tool(String jar, List<MinimalResolvedArtifact> classpath) {
+        this.jar = jar;
+        this.classpath = classpath;
+    }
+
+    public String getJar() {
+        return this.jar;
+    }
+
+    @ApiStatus.Internal
+    List<MinimalResolvedArtifact> getArtifacts() {
+        return this.classpath;
+    }
+
+    public List<String> getClasspath() {
+        return classpath.stream()
+            .map(art -> art.info().name())
+            .filter(name -> !name.equals(this.jar))
+            .toList();
+    }
+}

--- a/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/steps/Extract.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/steps/Extract.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
 package net.minecraftforge.forgedev.tasks.installer.steps;
 
 import net.minecraftforge.forgedev.tasks.installer.Tool;

--- a/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/steps/Extract.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/steps/Extract.java
@@ -1,0 +1,45 @@
+package net.minecraftforge.forgedev.tasks.installer.steps;
+
+import net.minecraftforge.forgedev.tasks.installer.Tool;
+
+import javax.inject.Inject;
+import java.io.Serial;
+import java.util.List;
+
+public class Extract extends Step {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    @Inject
+    public Extract(Tool tool) {
+        super(tool);
+        args.addAll(List.of(
+            "--task", "EXTRACT_FILES"
+        ));
+    }
+
+    public void archive(String archive) {
+        args.add("--archive");
+        args.add(archive);
+    }
+
+    public void extract(String from, String to) {
+        args.addAll(List.of(
+            "--from", from,
+            "--to", to
+        ));
+    }
+
+    public void optional(String from, String to) {
+        args.addAll(List.of(
+            "--from", from,
+            "--to", to,
+            "--optional", to
+        ));
+    }
+
+    public void executable(String executable) {
+        args.add("--exec");
+        args.add(executable);
+    }
+}

--- a/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/steps/ExtractBundle.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/steps/ExtractBundle.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
 package net.minecraftforge.forgedev.tasks.installer.steps;
 
 import net.minecraftforge.forgedev.tasks.installer.Tool;

--- a/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/steps/ExtractBundle.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/steps/ExtractBundle.java
@@ -1,0 +1,41 @@
+package net.minecraftforge.forgedev.tasks.installer.steps;
+
+import net.minecraftforge.forgedev.tasks.installer.Tool;
+
+import javax.inject.Inject;
+import java.io.Serial;
+import java.util.List;
+
+public class ExtractBundle extends Step {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    @Inject
+    public ExtractBundle(Tool tool) {
+        super(tool);
+        args.addAll(List.of(
+            "--task", "BUNDLER_EXTRACT"
+        ));
+    }
+
+    public void extract(String from, String to) {
+        args.addAll(List.of(
+            "--input", from,
+            "--output", to
+        ));
+    }
+
+    public void libraries() {
+        libraries("{MINECRAFT_JAR}", "{ROOT}/libraries/");
+    }
+
+    public void libraries(String from, String to) {
+        extract("{MINECRAFT_JAR}", "{ROOT}/libraries/");
+        args.add("--libraries");
+    }
+
+    public void jar(String from, String to) {
+        extract(from, to);
+        args.add("--jar-only");
+    }
+}

--- a/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/steps/Step.java
+++ b/src/main/groovy/net/minecraftforge/forgedev/tasks/installer/steps/Step.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+package net.minecraftforge.forgedev.tasks.installer.steps;
+
+import net.minecraftforge.forgedev.tasks.installer.Tool;
+
+import javax.inject.Inject;
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Step implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private final Tool tool;
+    public List<String> sides = List.of();
+
+    protected List<String> args = new ArrayList<>();
+    protected Map<String, String> outputs = new LinkedHashMap<>();
+
+    @Inject
+    public Step(Tool tool) {
+        this.tool = tool;
+    }
+
+    public Tool getTool() {
+        return this.tool;
+    }
+    public List<String> getSides() {
+        return sides;
+    }
+    public List<String> getArgs() {
+        return args;
+    }
+    public Map<String, String> getOutputs() {
+        return outputs;
+    }
+
+    public void setSides(List<String> sides) {
+        this.sides = sides;
+    }
+
+    public void setSide(String side) {
+        this.sides = List.of(side);
+    }
+
+    public void cache(String key, String value) {
+        outputs.put(key, value);
+    }
+}

--- a/src/main/groovy/net/minecraftforge/forgedev/tasks/patching/binary/BinaryPatcherExec.groovy
+++ b/src/main/groovy/net/minecraftforge/forgedev/tasks/patching/binary/BinaryPatcherExec.groovy
@@ -8,6 +8,7 @@ import groovy.transform.CompileStatic
 import groovy.transform.PackageScope
 import net.minecraftforge.forgedev.Tools
 import net.minecraftforge.forgedev.Util
+import net.minecraftforge.forgedev.tasks.SingleFileOutput
 import net.minecraftforge.forgedev.tasks.ToolExec
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
@@ -23,9 +24,10 @@ import org.gradle.api.tasks.OutputFile
 import javax.inject.Inject
 
 @CompileStatic
-@PackageScope abstract class BinaryPatcherExec extends ToolExec {
+@PackageScope abstract class BinaryPatcherExec extends ToolExec implements SingleFileOutput {
     // Shared
     abstract @InputFiles ConfigurableFileCollection getClean()
+    @Override
     abstract @OutputFile RegularFileProperty getOutput()
     abstract @Input @Optional ListProperty<String> getPrefix()
     abstract @Input Property<Boolean> getPack200()


### PR DESCRIPTION
Re-writes the installer tasks into a grouped system.
Basically drastically reduces the duplicate code (shaves 100 lines off the buildscript), and manages packing all the files as needed by introducing a bunch of helpers. As well as treating the tasks for building the installer jar as a single group.

Shove this into the experimental branch and see what i'm thinking.
Everything i'm doing, should be config cache and lazy config compatible.

```groovy

forgedev.installer("testInstaller") {
    dev = !forgedev.ci
    offline = false

    // Add extra libraries
    pack tasks.named('serverShimJar', Jar) // The Server executable jar IS needed to be packed, as the installer would need a spec bump in order to download it
    pack tasks.named('universalJar', Jar) // I don't think this is strictly needed to be packed anymore, will need to double check later
    // This isn't actually needed, but its here for some reason, probably wasn't deleted when then installer process was cleaned up
    library mcpArtifactString

    launcherLibrary tasks.named('universalJar', Jar)
    // We configure the launcher here to keep the order for easier diff, after publishing, move this to the LauncherJson configuration below
    launcherJson {
        // We create this during install, so it's not downloadable
        generated(tasks.named('applyClientBinPatches'), 'client')
    }

    launcherLibraries configurations.installerextra
    launcherLibraries configurations.installer

    var launcherId = "${minecraftVersion}-${project.name}-${forgeVersion}"
    var installertools = tool(buildLibs.installertools)
    var renamer = tool(buildLibs.renamer)
    var binarypatcher = tool(buildLibs.binarypatcher)

    jar {
        from(EXTRA_TXTS)
        from(rootProject.file('/forge_installer_logo.png')) {
            rename { 'big_logo.png' }
        }
        from(genClientBinPatches.output) {
            rename { 'data/client.lzma' }
        }
        from(genServerBinPatches.output) {
            rename { 'data/server.lzma' }
        }

        final var argsFile = rootProject.file('server_files/args.txt')
        final Map<String, Map<String, String>> tokens = [tokens: [
            SHIM_JAR_FILE: serverShimJar.archiveFileName.get(),
            MAVEN_PATH: mavenPath
        ]]
        from(argsFile) {
            filter(tokens, ReplaceTokens)
            into 'data'
            rename { 'unix_args.txt' }
        }
        from(argsFile) {
            filter(tokens, ReplaceTokens)
            into 'data'
            rename { 'win_args.txt' }
        }

        from(rootProject.file('server_files')) {
            filter(tokens, ReplaceTokens)
            into 'data'
            exclude 'args.txt'
        }

        jarSigner.sign(it)
    }
    json {
        icon = rootProject.file('icon.ico')
        executable tasks.named('serverShimJar', Jar)
        minecraft = minecraftVersion
        profileVersion = launcherId

        var projectArtifact = "${project.group}:${project.name}:${project.version}"

        data 'MOJMAPS', "[net.minecraft:client:${minecraftVersion}:mappings@tsrg]", "[net.minecraft:server:${minecraftVersion}:mappings@tsrg]"
        data 'MOJMAPS_SHA', downloadClientMappings.output, downloadServerMappings.output

        data 'MC_UNPACKED', "[net.minecraft:client:${minecraftVersion}]", "[net.minecraft:server:${minecraftVersion}:unpacked]"
        data 'MC_UNPACKED_SHA', setupMCP.clientRaw, setupMCP.serverExtracted

        data 'MC_OFF', "[net.minecraft:client:${minecraftVersion}:official]", "[net.minecraft:server:${minecraftVersion}:official]"
        data 'MC_OFF_SHA', createClientOfficial.output, createServerOfficial.output

        data 'BINPATCH', '/data/client.lzma', '/data/server.lzma'
        data 'PATCHED', "[$projectArtifact:client]", "[$projectArtifact:server]"
        data 'PATCHED_SHA', applyClientBinPatches.output, applyServerBinPatches.output

        def rename = (side, input) -> {
            step(renamer) {
                sides = [side]
                args = [
                    '--input', input,
                    '--output', '{MC_OFF}',
                    '--names', '{MOJMAPS}',
                    '--ann-fix', '--ids-fix', '--src-fix', '--record-fix', '--strip-sigs', '--reverse'
                ]
                cache '{MC_OFF}', '{MC_OFF_SHA}'
            }
        }

        steps = [
            extract(installertools) {
                side = 'server'
                archive '{INSTALLER}'
                extract 'data/README.txt', '{ROOT}/README.txt'
                extract 'data/run.sh', '{ROOT}/run.sh'
                executable '{ROOT}/run.sh'
                extract 'data/run.bat', '{ROOT}/run.bat'
                optional 'data/user_jvm_args.txt', '{ROOT}/user_jvm_args.txt'
                extract 'data/unix_args.txt', "{ROOT}/libraries/${mavenPath}/unix_args.txt"
                extract 'data/win_args.txt', "{ROOT}/libraries/${mavenPath}/win_args.txt"
            },
            extractBundle(installertools) {
                side = 'server'
                libraries()
            },
            extractBundle(installertools) {
                side = 'server'
                jar '{MINECRAFT_JAR}', '{MC_UNPACKED}'
                cache '{MC_UNPACKED}', '{MC_UNPACKED_SHA}'
            },
            step(installertools) {
                args = [
                    '--task', 'DOWNLOAD_MOJMAPS',
                    '--sanitize',
                    '--version', minecraftVersion,
                    '--side', '{SIDE}',
                    '--output', '{MOJMAPS}'
                ]
                cache '{MOJMAPS}', '{MOJMAPS_SHA}'
            },
            rename.call('server', '{MC_UNPACKED}'),
            rename.call('client', '{MINECRAFT_JAR}'),
            step(binarypatcher) {
                args = [
                    '--clean', '{MC_OFF}',
                    '--output', '{PATCHED}',
                    '--apply', '{BINPATCH}',
                    '--data', '--unpatched'
                ]
                cache '{PATCHED}', '{PATCHED_SHA}'
            }
        ]
    }

    launcherJson {
        // These are flags to preserve glitchy old behavior to make diffing easier, removing when migrating to production is recommended
        sortLibraries = false // Don't sort, makes things non-deterministic, but easier to diff old versions
        duplicateLibraries = true // Our 'bootstrap' layer go added twice
        librariesLast = false // Makes libraries be added before args

        id = launcherId
        inheritsFrom = minecraftVersion
        mainClass = 'net.minecraftforge.bootstrap.ForgeBootstrap'
        gameArgs = [ '--launchTarget', 'forge_client' ]
        jvmArgs = [ '-Djava.net.preferIPv6Addresses=system' ]
    }
}
```
